### PR TITLE
use replace instead of provide in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "issues": "https://github.com/phpseclib/phpseclib2_compat/issues",
         "source": "https://github.com/phpseclib/phpseclib2_compat"
     },
-    "provide": {
+    "replace": {
         "phpseclib/phpseclib": "2.0.30"
     },
     "require": {


### PR DESCRIPTION
`provide` is meant for packages that provides implementation for interfaces defined in another package
`replace` should be used to signal that installing this package will fulfil the requirement phpseclib/phpseclib: 2.0.30