### PR TITLE
allow private/public key swapped for RSA::encrypt() and RSA::decrypt()

### DIFF
--- a/src/Crypt/RSA.php
+++ b/src/Crypt/RSA.php
@@ -831,27 +831,23 @@ class RSA
      */
     public function encrypt($plaintext)
     {
-        if ($this->key instanceof PublicKey) {
-            switch ($this->encryptionMode) {
-                case self::ENCRYPTION_PKCS1:
-                    $len = ($this->key->getLength() - 88) >> 3;
-                    break;
-                case self::ENCRYPTION_NONE:
-                    $len = $this->key->getLength() >> 3;
-                    break;
-                //case self::ENCRYPTION_OAEP:
-                default:
-                    $len = ($this->key->getLength() - 2 * $this->key->getHash()->getLength() - 16) >> 3;
-            }
-            $plaintext = str_split($plaintext, $len);
-            $ciphertext = '';
-            foreach ($plaintext as $m) {
-                $ciphertext.= $this->key->encrypt($m);
-            }
-            return $ciphertext;
+        switch ($this->encryptionMode) {
+            case self::ENCRYPTION_PKCS1:
+                $len = ($this->key->getLength() - 88) >> 3;
+                break;
+            case self::ENCRYPTION_NONE:
+                $len = $this->key->getLength() >> 3;
+                break;
+            //case self::ENCRYPTION_OAEP:
+            default:
+                $len = ($this->key->getLength() - 2 * $this->key->getHash()->getLength() - 16) >> 3;
         }
-
-        return false;
+        $plaintext = str_split($plaintext, $len);
+        $ciphertext = '';
+        foreach ($plaintext as $m) {
+            $ciphertext.= $this->key->encrypt($m);
+        }
+        return $ciphertext;
     }
 
     /**
@@ -864,23 +860,19 @@ class RSA
      */
     public function decrypt($ciphertext)
     {
-        if ($this->key instanceof PrivateKey) {
-            $len = $this->key->getLength() >> 3;
-            $ciphertext = str_split($ciphertext, $len);
-            $ciphertext[count($ciphertext) - 1] = str_pad($ciphertext[count($ciphertext) - 1], $len, chr(0), STR_PAD_LEFT);
+        $len = $this->key->getLength() >> 3;
+        $ciphertext = str_split($ciphertext, $len);
+        $ciphertext[count($ciphertext) - 1] = str_pad($ciphertext[count($ciphertext) - 1], $len, chr(0), STR_PAD_LEFT);
 
-            $plaintext = '';
-            foreach ($ciphertext as $c) {
-                try {
-                    $plaintext.= $this->key->decrypt($c);
-                } catch (\Exception $e) {
-                    return false;
-                }
+        $plaintext = '';
+        foreach ($ciphertext as $c) {
+            try {
+                $plaintext.= $this->key->decrypt($c);
+            } catch (\Exception $e) {
+                return false;
             }
-            return $plaintext;
         }
-
-        return false;
+        return $plaintext;
     }
 
     /**


### PR DESCRIPTION
we used swapped keys to sign while keeping the resulting size to a minimum for short inputs. this was possible with the version 2 without any issues. so i propose we restore that functionality to be compatible with v2.

https://github.com/phpseclib/phpseclib/blob/5a903ae520d162fa62bd0ca2f3b47625d72d6a0a/phpseclib/Crypt/RSA.php#L3190-L3226